### PR TITLE
Install tvthemes from git per docs since no longer on CRAN.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,7 +35,9 @@ RUN conda install -y \
     r-skimr\
     r-wesanderson
 
-RUN R -e "install.packages(c('lterdatasampler', 'tvthemes', 'NatParksPalettes'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+RUN R -e "devtools::install_github('Ryo-N7/tvthemes')"
+
+RUN R -e "install.packages(c('lterdatasampler', 'NatParksPalettes'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
 
 RUN /usr/local/bin/fix-permissions "${CONDA_DIR}" || true
 


### PR DESCRIPTION
Install directly from upstream: https://github.com/Ryo-N7/tvthemes/

Since package is no longer on CRAN: https://cran.r-project.org/web/packages/tvthemes/index.html

And not available in Conda Forge.